### PR TITLE
Support batch data load on Microsoft SQL Server 2022

### DIFF
--- a/excel-importer/src/com/axonivy/util/excel/importer/EntityDataLoader.java
+++ b/excel-importer/src/com/axonivy/util/excel/importer/EntityDataLoader.java
@@ -53,6 +53,9 @@ public class EntityDataLoader {
     Connection con = access.obtainConnection();
     try {
       var dbProduct = con.getMetaData().getClass().getName();
+      if (dbProduct.contains("microsoft")) {
+        con.createStatement().execute("SET IDENTITY_INSERT " + tableNameOf(entity) + " ON");
+      }
 
       con.setAutoCommit(false);
       var stmt = loadRows(entity, rows, con);
@@ -63,6 +66,9 @@ public class EntityDataLoader {
         String moveAutoIncrement = "ALTER SEQUENCE " + tableNameOf(entity) + "_id_seq RESTART "
             + "WITH " + (inserted.length + 1) + ";";
         con.createStatement().executeUpdate(moveAutoIncrement);
+      }
+      if (dbProduct.contains("microsoft")) {
+        con.createStatement().execute("SET IDENTITY_INSERT " + tableNameOf(entity) + " OFF");
       }
     } finally {
       access.releaseConnection(con);


### PR DESCRIPTION
without this flag-toggling, MS SQL Batch importer fails

```
java.sql.BatchUpdateException: Cannot insert explicit value for identity column in table 'SampleMS81' when IDENTITY_INSERT is set to OFF.
	at com.microsoft.sqlserver.jdbc.SQLServerPreparedStatement.executeBatch(SQLServerPreparedStatement.java:2295)
	at ch.ivyteam.db.jdbc.proxy.StatementProxy.executeBatch(StatementProxy.java:166)
	at com.axonivy.util.excel.importer.EntityDataLoader.load(EntityDataLoader.java:62)
	at com.axonivy.util.excel.importer.EntityDataLoader.load(EntityDataLoader.java:43)
	at com.axonivy.util.excel.importer.wizard.ExcelImportProcessor.lambda$3(ExcelImportProcessor.java:148)
	at ch.ivyteam.util.callable.AbstractExecutionContext.callInContext(AbstractExecutionContext.java:10)
	at com.axonivy.util.excel.importer.wizard.ExcelImportProcessor.importData(ExcelImportProcessor.java:146)
	at com.axonivy.util.excel.importer.wizard.ExcelImportProcessor.importExcel(ExcelImportProcessor.java:124)
	at com.axonivy.util.excel.importer.wizard.ExcelImportProcessor.lambda$0(ExcelImportProcessor.java:97)
	at org.eclipse.core.internal.resources.Workspace.run(Workspace.java:2457)
	at org.eclipse.core.internal.resources.Workspace.run(Workspace.java:2482)
	at com.axonivy.util.excel.importer.wizard.ExcelImportProcessor.run(ExcelImportProcessor.java:94)
	at org.eclipse.jface.operation.ModalContext$ModalContextThread.run(ModalContext.java:124)

```

![mssql-insert-batch](https://github.com/user-attachments/assets/8dd8b0f8-425b-4b2c-80d6-03f8bfd8f9f9)
